### PR TITLE
Bugfix log extra

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Date: ??/??/??
 
 - Added multi gauge support
 
+- Improved regexes for dw_analyze
+
+
 0.2.0
 -----
 

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -43,7 +43,7 @@ def dw_analyze(path):
 
     # compile regexes
     regex_lf = re.compile('(LogFactory.get_instance)')
-    regex_log = re.compile('\.(?:info|warn|warning|error|critical)\((\".*\").*\)')
+    regex_log = re.compile('\.(?:info|warn|warning|error|critical)\(((["\']).*?\\2)')
     regex_inc = re.compile('\.(?:info|warn|warning|error|critical)\((.*(?:\+|\.format\().*).*\)')
     regex_com = re.compile('\".*\"\,')
     found_lf = False
@@ -124,7 +124,7 @@ dw_dict = {
             # datadog metrics that will use ++'''
 
         for item in line_cache:
-            recommended_str += '\n            (' + item[3] + ', "' + _ddify(item[3], False) + '"),'
+            recommended_str += '\n            (' + item[3][0] + ', "' + _ddify(item[3][0], False) + '"),'
 
         recommended_str += '''
         ],
@@ -136,7 +136,7 @@ dw_dict = {
 
         for item in line_cache:
             if len(regex_com.findall(item[2])) > 0:
-                recommended_str += '\n            (' + item[3] + ', "' + _ddify(item[3], False) + '", "<extras.key.path>"),'
+                recommended_str += '\n            (' + item[3][0] + ', "' + _ddify(item[3][0], False) + '", "<extras.key.path>"),'
 
         recommended_str += '''
         ]

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -45,7 +45,7 @@ def dw_analyze(path):
     regex_lf = re.compile('(LogFactory.get_instance)')
     regex_log = re.compile('\.(?:info|warn|warning|error|critical)\(((["\']).*?\\2)')
     regex_inc = re.compile('\.(?:info|warn|warning|error|critical)\((.*(?:\+|\.format\().*).*\)')
-    regex_com = re.compile('\".*\"\,')
+    regex_com = re.compile('((["\']).*\\2),')
     found_lf = False
     line_cache = []
     unknown_cache = []

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -45,7 +45,7 @@ def dw_analyze(path):
     regex_lf = re.compile('(LogFactory.get_instance)')
     regex_log = re.compile('\.(?:info|warn|warning|error|critical)\(((["\']).*?\\2)')
     regex_inc = re.compile('\.(?:info|warn|warning|error|critical)\((.*(?:\+|\.format\().*).*\)')
-    regex_com = re.compile('((["\']).*\\2),')
+    regex_com = re.compile('((["\']).*?\\2),')
     found_lf = False
     line_cache = []
     unknown_cache = []

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.4.0'
+__version__ = '0.3.0'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/tests/example4.out
+++ b/tests/example4.out
@@ -26,6 +26,8 @@ dw_dict = {
         # and are shown here for illustration purposes only
         'gauges': [
             
+            ('this is a test', "this_is_a_test", "<extras.key.path>"),
+            ('This is another "test"', "this_is_another_test", "<extras.key.path>"),
         ]
     },
     'options': {

--- a/tests/example4.out
+++ b/tests/example4.out
@@ -1,0 +1,40 @@
+Valid Lines
+-----------
+./tests/example4/example.py
+   3 : logger.info('this is a test', extra={'foo': 'bar'})
+   4 : logger.warn('This is another "test"', extra={'foo': "bar"})
+
+Auto-Generated Template Settings
+--------------------------------
+
+dw_dict = {
+    'name': '<my_project>',
+    'tags': [
+        # high level tags that everything in your app will have
+        'item:descriptor'
+    ],
+    'metrics': {
+        # By default, everything is a counter using the concatentated log string
+        # the 'counters' key is NOT required, it is shown here for illustration
+        'counters': [
+            # datadog metrics that will use ++
+            ('this is a test', "this_is_a_test"),
+            ('This is another "test"', "this_is_another_test"),
+        ],
+        # datadog metrics that have a predefined value like `51`
+        # These metrics override any 'counter' with the same key,
+        # and are shown here for illustration purposes only
+        'gauges': [
+            
+        ]
+    },
+    'options': {
+        # use statsd for local testing, see docs
+        'statsd_host': 'localhost',
+        'statsd_port': 8125,
+        'local': True,
+    },
+
+}
+
+Ensure the above dictionary is passed into `dw_config()`

--- a/tests/example4.out
+++ b/tests/example4.out
@@ -2,7 +2,7 @@ Valid Lines
 -----------
 ./tests/example4/example.py
    3 : logger.info('this is a test', extra={'foo': 'bar'})
-   4 : logger.warn('This is another "test"', extra={'foo': "bar"})
+   4 : logger.warn('This is another "test"', extra={'foo': "bar", 'bar': "baz", "lorem": "ipsum"})
 
 Auto-Generated Template Settings
 --------------------------------

--- a/tests/example4/example.py
+++ b/tests/example4/example.py
@@ -1,0 +1,5 @@
+logger = LogFactory.get_instance()
+
+logger.info('this is a test', extra={'foo': 'bar'})
+logger.warn('This is another "test"', extra={'foo': "bar"})
+

--- a/tests/example4/example.py
+++ b/tests/example4/example.py
@@ -1,5 +1,5 @@
 logger = LogFactory.get_instance()
 
 logger.info('this is a test', extra={'foo': 'bar'})
-logger.warn('This is another "test"', extra={'foo': "bar"})
+logger.warn('This is another "test"', extra={'foo': "bar", 'bar': "baz", "lorem": "ipsum"})
 

--- a/tests/test_dog_whistle.py
+++ b/tests/test_dog_whistle.py
@@ -308,3 +308,14 @@ class DogWhistleTest(TestCase):
             call('cool3.some_log_gauge3', 55, tags=['list:strings']),
         ]
         g.assert_has_calls(calls)
+
+    def test_16_log_with_extra(self):
+        expected = None
+        with open('./tests/example4.out') as ff:
+            expected = ff.read().strip()
+
+        with captured_output() as (out, err):
+            dw_analyze('./tests/example4')
+
+        output = out.getvalue().strip()
+        self.assertEqual(output, expected)


### PR DESCRIPTION
Dog Whistle's log message detection currently does greedy string matching and only looks for double-quoted log messages ~ if a log message uses single quotes or has an extras dictionary with quoted keys or values, the messages identified will be garbled. 

This PR updates the regex used to identify log messages to match quote pairs properly and perform non-greedy string matching. While contrived log messages with complex embedded quotes could still "break" this regex, it is significantly more robust. 

The regex used to match potential gauges has also been updated with the same improvements.