### PR TITLE
strip trailing periods from datadog keys

### DIFF
--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -312,7 +312,7 @@ def _ddify(message, prepend=True):
     if prepend:
         message = '{}.{}'.format(_dw_configuration['name'], message)
     message = re.sub(r'[^0-9a-zA-Z_. ]', '', message)
-    return message.lower().replace(' ', '_').replace('"', '')[:MAX_LENGTH]
+    return message.rstrip('.').lower().replace(' ', '_').replace('"', '')[:MAX_LENGTH]
 
 
 def _get_value(item, key):

--- a/tests/example4.out
+++ b/tests/example4.out
@@ -3,6 +3,7 @@ Valid Lines
 ./tests/example4/example.py
    3 : logger.info('this is a test', extra={'foo': 'bar'})
    4 : logger.warn('This is another "test"', extra={'foo': "bar", 'bar': "baz", "lorem": "ipsum"})
+   6 : logger.info('Should strip trailing periods.')
 
 Auto-Generated Template Settings
 --------------------------------
@@ -20,6 +21,7 @@ dw_dict = {
             # datadog metrics that will use ++
             ('this is a test', "this_is_a_test"),
             ('This is another "test"', "this_is_another_test"),
+            ('Should strip trailing periods.', "should_strip_trailing_periods"),
         ],
         # datadog metrics that have a predefined value like `51`
         # These metrics override any 'counter' with the same key,

--- a/tests/example4/example.py
+++ b/tests/example4/example.py
@@ -3,3 +3,4 @@ logger = LogFactory.get_instance()
 logger.info('this is a test', extra={'foo': 'bar'})
 logger.warn('This is another "test"', extra={'foo': "bar", 'bar': "baz", "lorem": "ipsum"})
 
+logger.info('Should strip trailing periods.')


### PR DESCRIPTION
This PR removes trailing periods from slugified log message keys. Trailing periods screw up graphite's logging, and are generally ambiguous in the context of dot-separated hierarchies. 

