### PR TITLE
docs update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# pycharm stuff
+.idea
+
 # Distribution / packaging
 .Python
 env/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -289,8 +289,6 @@ Local Datadog Agent
 
 Here, we assume you have a local `Datadog Agent <http://docs.datadoghq.com/guides/basic_agent_usage/>`_ running on your local machine. Please refer to the official documentation for troubleshooting connecting your machine to Datadog.
 
-.. note:: The majority of this guide should work on all platforms, however final Datadog + Docker integration may need to be conducted on a linux box only.
-
 At this point you should have a Datadog Agent installed and running successfully on your machine. Refer to your datadog configuration file to get the location of the ``statsd`` host that Datadog is running. For example, on unix based systems the log location is:
 
 ::
@@ -363,7 +361,7 @@ You will want to make sure your final application can hit the local Datadog Agen
 
     'statsd_host': "localhost",
 
-within your ``options``. If using Docker, set your configuration to
+within your ``options``. If using Docker on Linux, set your configuration to
 
 ::
 
@@ -371,9 +369,15 @@ within your ``options``. If using Docker, set your configuration to
       - DATADOG_LOCAL=True
       - DATADOG_STATSD_HOST=172.17.0.1 # linux only
 
-to ensure your container can hit the local Datadog Agent.
+If using Docker on Mac OS, set your configuration to
 
-.. warning:: At time of writing, Docker for Mac does not provide the ability for a container to reach the docker host. You should test your setup on a machine that has the ability to access the host so it can talk to the Datadog Agent running locally.
+::
+
+    environment:
+      - DATADOG_LOCAL=True
+      - DATADOG_STATSD_HOST=docker.for.mac.localhost # Mac only
+
+to ensure your container can hit the local Datadog Agent.
 
 Once your application is configured, you can see the metrics in your `Metrics Summary <https://app.datadoghq.com/metric/summary>`_ like below, and begin building custom dashboards, graphs, and alerts based on your logging.
 


### PR DESCRIPTION
Previously one had to create a loopback alias IP when trying to enabled coms between a docker container and the host. This is relevant to DogWhistle when testing DogWhistle with a local DataDog agent running on host. It is now possible to use a special DNS record which allows a docker container reach the host.

This PR is a doc update to reflect this ability.