### PR TITLE
Adjust Dog Whistle to allow custom tags per-message

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -182,7 +182,7 @@ Here, we supply a normal dictionary to be logged to the logger instance, but Dog
 
 Lastly, ``tags`` are something that will always be included in your datadog stats. Here, you can specify a unique descriptor or other item to identify your process from the rest of the group. These tags are optional, but are helpful.
 
-Setting ``allow_extra_tags=True`` in your configuration will allow you to override global tags on a per-message basis:
+Setting ``allow_extra_tags=True`` in your configuration will allow you to add additional tags on a per-message basis:
 
 ::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -182,6 +182,14 @@ Here, we supply a normal dictionary to be logged to the logger instance, but Dog
 
 Lastly, ``tags`` are something that will always be included in your datadog stats. Here, you can specify a unique descriptor or other item to identify your process from the rest of the group. These tags are optional, but are helpful.
 
+Setting ``allow_extra_tags=True`` in your configuration will allow you to override global tags on a per-message basis:
+
+::
+
+    logger.info("this is a test",extra={'tags': ['my:tag', 'my:othertag']})
+
+.. note:: Tags are not sent while dog whistle is in local configuration mode. 
+
 Local Configuration
 -------------------
 

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -284,7 +284,11 @@ def dw_callback(message, extras):
                     log.warning("Could not find key " + item['value'] + " inside extras")
                 else:
                     the_msg = _ddify(item['name'])
-                    _gauge(the_msg, value, tags=_dw_configuration['tags'])
+
+                    if 'tags' in extras:
+                        _gauge(the_msg, value, tags=extras['tags'])
+                    else:
+                        _gauge(the_msg, value, tags=_dw_configuration['tags'])
         # increment counter metric
         else:
             if message in _dw_configuration['metrics']['c_mapper']:
@@ -293,7 +297,10 @@ def dw_callback(message, extras):
             else:
                 the_msg = _ddify(message)
 
-            _increment(the_msg, tags=_dw_configuration['tags'])
+            if 'tags' in extras:
+                _increment(the_msg, tags=extras['tags'])
+            else:
+                _increment(the_msg, tags=_dw_configuration['tags'])
     else:
         log.warning("Tried to increment attribute before configuration")
 

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -290,7 +290,7 @@ def dw_callback(message, extras):
                     the_msg = _ddify(item['name'])
 
                     if 'tags' in extras and _dw_configuration['allow_extra_tags']:
-                        _gauge(the_msg, value, tags=extras['tags'])
+                        _gauge(the_msg, value, tags=_dw_configuration['tags'] + extras['tags'])
                     else:
                         _gauge(the_msg, value, tags=_dw_configuration['tags'])
         # increment counter metric
@@ -302,7 +302,7 @@ def dw_callback(message, extras):
                 the_msg = _ddify(message)
 
             if 'tags' in extras and _dw_configuration['allow_extra_tags']:
-                _increment(the_msg, tags=extras['tags'])
+                _increment(the_msg, tags=_dw_configuration['tags'] + extras['tags'])
             else:
                 _increment(the_msg, tags=_dw_configuration['tags'])
     else:

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -197,6 +197,10 @@ def dw_config(settings):
             log.debug("no tags provided")
             _dw_configuration['tags'] = []
 
+        if 'allow_extra_tags' not in _dw_configuration:
+            log.debug("defaulting to no extra tags")
+            _dw_configuration['allow_extra_tags'] = False
+
         # configure local testing vs with datadog
         if 'local' in _dw_configuration['options'] and _dw_configuration['options']['local'] == True:
             from statsd import StatsClient
@@ -285,7 +289,7 @@ def dw_callback(message, extras):
                 else:
                     the_msg = _ddify(item['name'])
 
-                    if 'tags' in extras:
+                    if 'tags' in extras and _dw_configuration['allow_extra_tags']:
                         _gauge(the_msg, value, tags=extras['tags'])
                     else:
                         _gauge(the_msg, value, tags=_dw_configuration['tags'])
@@ -297,7 +301,7 @@ def dw_callback(message, extras):
             else:
                 the_msg = _ddify(message)
 
-            if 'tags' in extras:
+            if 'tags' in extras and _dw_configuration['allow_extra_tags']:
                 _increment(the_msg, tags=extras['tags'])
             else:
                 _increment(the_msg, tags=_dw_configuration['tags'])

--- a/tests/test_dog_whistle.py
+++ b/tests/test_dog_whistle.py
@@ -104,6 +104,7 @@ class DogWhistleTest(TestCase):
                     }]
                 }
             },
+            'allow_extra_tags': False,
             'name': 'cool',
             'options': {'local': True, 'statsd_host': 'localhost',
             'statsd_port': 8125},

--- a/tests/test_dog_whistle.py
+++ b/tests/test_dog_whistle.py
@@ -320,3 +320,28 @@ class DogWhistleTest(TestCase):
 
         output = out.getvalue().strip()
         self.assertEqual(output, expected)
+
+    @patch('dog_whistle._increment')
+    def test_17_extra_tags(self, i):
+        _reset()
+        configs = {
+            'name': 'cool2',
+            'tags': [
+                'list:strings'
+            ],
+            'allow_extra_tags': True,
+            'metrics': {
+                'counters': [('message', 'dd.key')],
+                'gauges': [("some log", "some_log", "key.key2.crazy"),],
+            },
+            'options': {
+                'statsd_host': 'localhost',
+                'statsd_port': 8125,
+                'local': True,
+            }
+        }
+        dw_config(configs)
+
+        dw_callback("message", {"tags":["am:cat","is:dog"]})
+
+        i.assert_called_once_with('cool2.dd.key', tags=['list:strings',"am:cat","is:dog"])


### PR DESCRIPTION
This PR includes the ability to allow custom tags per-message. This can be turned on/off via the `allow_extra_tags` configuration  boolean.  An example message with custom tags is below:

```
logger.info("this is a test",extra={'tags': ['my:tag', 'my:othertag']})
```

I have also updated the docs and made a note about tags not working on a `local=True` setup. 