### PR TITLE
Datadog statsd client does not need credentials

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -103,9 +103,6 @@ By analyzing only your valid lines, the dog whistle library dumps out a dictiona
 
 * **name** - the name of your overall project
 
-If you do not provide an ``options`` key, it is assumed you will be passing your ``DATADOG_API_KEY`` and ``DATADOG_APP_KEY`` via environment variables.
-
-
 * **options** - the options to be passed to configure the statsd or datadog setup
 
 For example:
@@ -393,10 +390,16 @@ Once your application is configured, you can see the metrics in your `Metrics Su
    :alt: Statsd
    :align:   center
 
-Direct API Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^
+DataDog Statsd Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Direct Datadog API Configuration is planned for a future release.
+To enable DataDog integration simply set the ``local`` option to False, and ensure that ``DATADOG_STATSD_HOST`` is pointing to a dd-agent instance. 
+
+::
+
+    environment:
+      - DATADOG_LOCAL=False
+      - DATADOG_STATSD_HOST=172.17.0.1
 
 Wrapping Up
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -393,7 +393,7 @@ Once your application is configured, you can see the metrics in your `Metrics Su
 DataDog Statsd Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To enable DataDog integration simply set the ``local`` option to False, and ensure that ``DATADOG_STATSD_HOST`` is pointing to a dd-agent instance. 
+To enable DataDog integration simply set the ``local`` option to False, and ensure that ``statsd_host`` is pointing to a dd-agent. For instance:
 
 ::
 

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -223,7 +223,7 @@ def dw_config(settings):
                 log.error("Unknown statsd config for DataDog setup")
                 raise Exception("Unknown statsd config for DataDog setup")
 
-            initialize(statsd_host=_dw_configuration['options']['statsd_host'], statsd_port=_dw_configuration['options']['statsd_port'])
+            initialize(**_dw_configuration['options'])
             _dw_stats = statsd
 
         # generate override mappings

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -218,16 +218,12 @@ def dw_config(settings):
         else:
             from datadog import initialize, statsd
 
-            # ensure vars are set
-            if 'api_key' not in _dw_configuration['options'] and \
-                    os.getenv('DATADOG_API_KEY', None) is None:
-                raise Exception("Please provide DataDog API Key")
+            if 'statsd_host' not in _dw_configuration['options'] or \
+                    'statsd_port' not in _dw_configuration['options']:
+                log.error("Unknown statsd config for datadog statsd")
+                raise Exception("Unknown statsd config for datadog statsd")
 
-            if 'app_key' not in _dw_configuration['options'] and \
-                    os.getenv('DATADOG_APP_KEY', None) is None:
-                raise Exception("Please provide DataDog APP Key")
-
-            initialize(**_dw_configuration['options'])
+            initialize(statsd_host=_dw_configuration['options']['statsd_host'], statsd_port=_dw_configuration['options']['statsd_port'])
             _dw_stats = statsd
 
         # generate override mappings

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -220,8 +220,8 @@ def dw_config(settings):
 
             if 'statsd_host' not in _dw_configuration['options'] or \
                     'statsd_port' not in _dw_configuration['options']:
-                log.error("Unknown statsd config for datadog statsd")
-                raise Exception("Unknown statsd config for datadog statsd")
+                log.error("Unknown statsd config for DataDog setup")
+                raise Exception("Unknown statsd config for DataDog setup")
 
             initialize(statsd_host=_dw_configuration['options']['statsd_host'], statsd_port=_dw_configuration['options']['statsd_port'])
             _dw_stats = statsd

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.1'
+__version__ = '0.5.0'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/tests/test_dog_whistle.py
+++ b/tests/test_dog_whistle.py
@@ -123,26 +123,15 @@ class DogWhistleTest(TestCase):
         }
         with self.assertRaises(Exception) as e:
             dw_config(configs)
-        self.assertEquals(e.exception.args[0], "Please provide DataDog API Key")
-
-        # assert no app key
-        configs = {
-            'name': 'cool',
-            'options': {
-                'api_key': 'neat'
-            }
-        }
-        with self.assertRaises(Exception) as e:
-            dw_config(configs)
-        self.assertEquals(e.exception.args[0], "Please provide DataDog APP Key")
+        self.assertEquals(e.exception.args[0], "Unknown statsd config for DataDog setup")
 
     def test_08_config_dd(self):
         _reset()
         configs = {
             'name': 'cool',
             'options': {
-                'api_key': 'neat',
-                'app_key': 'neat2',
+                'statsd_host': 'localhost',
+                'statsd_port': 8125,
             }
         }
         dw_config(configs)


### PR DESCRIPTION
[Per the dd-py rtd - ](http://datadogpy.readthedocs.io/en/latest/#datadog.statsd) - API credentials are not needed when using the datadog statsd python client. It just needs to be pointed to a functioning dd-agent. 

I also updated the unit tests to reflect this change. 