### PR TITLE
Normalize tags to lowercase

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Change Log
 
 This page serves to document any changes made between releases.
 
+0.6.0
+=====
+
+Date: ??/??/??
+
+- Normalize to lowercase all tags
+
 0.5.0
 -----
 

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -347,6 +347,8 @@ def _increment(name, tags):
     global _dw_stats
     global _dw_local
 
+    tags = _normalize_tags(tags)
+
     if _dw_local:
         _dw_stats.increment(stat=name)
     else:
@@ -364,12 +366,17 @@ def _gauge(name, value, tags):
     global _dw_stats
     global _dw_local
 
+    tags = _normalize_tags(tags)
+
     if _dw_local:
         _dw_stats.gauge(stat=name, value=value)
     else:
         _dw_stats.gauge(metric=name, value=value, tags=tags)
 
     log.info("metric guage " + name)
+
+def _normalize_tags(tags):
+    return [t.lower() for t in tags]
 
 def _get_dw_stats():
     """Returns the statsd implementation in use"""

--- a/dog_whistle/__init__.py
+++ b/dog_whistle/__init__.py
@@ -371,6 +371,11 @@ def _gauge(name, value, tags):
 
     log.info("metric guage " + name)
 
+def _get_dw_stats():
+    """Returns the statsd implementation in use"""
+    global _dw_stats
+    return _dw_stats
+
 def _get_config():
     """Returns the current configuration of the module"""
     global _dw_configuration

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.6.1'
+__version__ = '0.6.0'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/dog_whistle/__version__.py
+++ b/dog_whistle/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/tests/test_dog_whistle.py
+++ b/tests/test_dog_whistle.py
@@ -353,10 +353,10 @@ class DogWhistleTest(TestCase):
             }
         }
         dw_config(configs)
-        with patch.object(_get_dw_stats(), 'gauge') as gauge:
+        with patch.object(_get_dw_stats(), 'gauge') as statsd_gauge:
             extras = {'key': {'key2': 41}}
             dw_callback("some log", extras)
-            gauge.assert_called_once_with(metric='cool2.some_log', tags=['list:strings'], value=41)
+            statsd_gauge.assert_called_once_with(metric='cool2.some_log', tags=['list:strings'], value=41)
 
     def test_19_case_insensitive_tags_increment(self):
         _reset()
@@ -372,7 +372,7 @@ class DogWhistleTest(TestCase):
             }
         }
         dw_config(configs)
-        with patch.object(_get_dw_stats(), 'increment') as increment:
+        with patch.object(_get_dw_stats(), 'increment') as statsd_increment:
             dw_callback("message", {})
-            increment.assert_called_once_with(metric='cool3.message', tags=['list:strings'])
+            statsd_increment.assert_called_once_with(metric='cool3.message', tags=['list:strings'])
 


### PR DESCRIPTION
This PR normalizes tags sent to DataDog to lowercase. DataDog tags are case sensitive and human error may cause tag fragmentation that cause certain monitors/dashboards to not operate correctly.